### PR TITLE
Fix parsing of floats with no precision

### DIFF
--- a/src/Microtime.php
+++ b/src/Microtime.php
@@ -60,7 +60,12 @@ class Microtime implements MicrotimeInterface
      */
     public static function fromFloat(float $float): Microtime
     {
-        return new static(\DateTime::createFromFormat('U.u', (string) $float));
+        $string = (string) $float;
+        $dotPosition = strpos($string, '.');
+        if ($dotPosition === false) {
+            $string = sprintf('%s.%s', $string, '0');
+        }
+        return new static(\DateTime::createFromFormat('U.u', $string));
     }
 
     /**

--- a/tests/MicrotimeTest.php
+++ b/tests/MicrotimeTest.php
@@ -5,10 +5,12 @@ use Reply\Microtime\Microtime;
 
 class MicrotimeTest extends TestCase
 {
-    const VALUE_STRING       = '0.66153000 1590417215';
-    const VALUE_MICROSECONDS = 1590417215661530;
-    const VALUE_SECONDS      = 1590417215;
-    const VALUE_FLOAT        = 1590417215.6615;
+    const VALUE_STRING               = '0.66153000 1590417215';
+    const VALUE_MICROSECONDS         = 1590417215661530;
+    const VALUE_SECONDS              = 1590417215;
+    const VALUE_FLOAT                = 1590417215.6615;
+    const VALUE_FLOAT_ZERO_PRECISION = 2.0;
+    const VALUE_FLOAT_LOW_PRECISION  = 2.01;
 
     public function testCanBeCreatedFromCurrentTimestamp()
     {
@@ -28,6 +30,9 @@ class MicrotimeTest extends TestCase
     public function testCanBeCreatedFromFloat()
     {
         $this->checkObject(Microtime::fromFloat( static::VALUE_FLOAT ));
+        // a float can be rounded by PHP to 1 zero precision. this has to work too
+        $this->checkObject(Microtime::fromFloat( static::VALUE_FLOAT_LOW_PRECISION ));
+        $this->checkObject(Microtime::fromFloat( static::VALUE_FLOAT_ZERO_PRECISION ));
     }
 
     public function testCanBeCreatedFromMicroseconds()


### PR DESCRIPTION
When writing tests in an other project i found that the Microtime::fromFloat method does not work with floats that have only zeros as precision.
This is because `2.0000` as string is only `"2"`. And this can not be parsed by `\DateTime::createFromFormat('U.u', $string)`